### PR TITLE
Support individual file targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Use this to understand I/O behavior in a system and to increase iteration speed 
 
 * [Documentation on racket-lang.org](https://docs.racket-lang.org/file-watchers/index.html?q=file-watchers)
 * `raco test *.rkt` to run tests
-* `racket main.rkt [-m apathetic, robust, or intensive] DIRECTORY ...` to watch the given directories with one of the methods in the project. See the documentation for more.
 * `raco setup -l file-watchers` to build the package and documentation.
+* `raco file-watchers -h` for CLI use

--- a/cli.rkt
+++ b/cli.rkt
@@ -1,45 +1,48 @@
 #lang racket/base
 
-(require
-  "./main.rkt"
-  "./threads.rkt"
-  racket/format
-  racket/string
-  racket/cmdline
-  racket/list
-  raco/command-name)
+(module+ main
+  (require
+    "./main.rkt"
+    "./threads.rkt"
+    racket/format
+    racket/string
+    racket/cmdline
+    racket/list
+    raco/command-name)
 
-(define method-string (make-parameter "robust"))
-(define paths (command-line
-  #:program (short-program+command-name)
-  #:once-each
-  [("-m" "--method")  user-method
-                      ("Use method: apathetic, intensive, robust (Default: robust)."
-                       "Be warned that only 'robust' is cross-platform.")
-                      (method-string user-method)]
-  #:args user-path-strings
-  (if (empty? user-path-strings)
-      (list (current-directory))
-      (map string->path user-path-strings))))
+  (define method-string (make-parameter "robust"))
+  (define paths (command-line
+    #:program (short-program+command-name)
+    #:once-each
+    [("-m" "--method")  user-method
+                        ("Use method: apathetic, intensive, robust (Default: robust)."
+                         "Be warned that only 'robust' is cross-platform.")
+                        (method-string user-method)]
+    #:args user-path-strings
+    (if (empty? user-path-strings)
+        (list (current-directory))
+        (map string->path user-path-strings))))
 
-(define normalized-method-string
-  (case (method-string)
-     [("robust" "intensive" "apathetic") (method-string)]
-     [else "robust"]))
+  (define normalized-method-string
+    (case (method-string)
+       [("robust" "intensive" "apathetic") (method-string)]
+       [else "robust"]))
 
-(define method (case normalized-method-string
-   [("robust")    robust-watch]
-   [("intensive") intensive-watch]
-   [("apathetic") apathetic-watch]
-   [else          robust-watch]))
+  (define method (case normalized-method-string
+     [("robust")    robust-watch]
+     [("intensive") intensive-watch]
+     [("apathetic") apathetic-watch]
+     [else          robust-watch]))
 
-(when (not (equal? normalized-method-string (method-string)))
-  (printf "Unrecognized method: ~a. Falling back to robust watch.~n" (method-string)))
+  (when (not (equal? normalized-method-string (method-string)))
+    (printf "Unrecognized method: ~a. Falling back to robust watch.~n" (method-string)))
 
-(printf "Starting ~a watch over paths:~n~a~n~n"
-      normalized-method-string
-      (string-join
-        (map (lambda (p) (~a "-->  " p)) paths)
-        (~a "~n")))
+  (printf "Starting ~a watch over paths:~n~a~n~n"
+        normalized-method-string
+        (string-join
+          (map (lambda (p) (~a "-->  " p)) paths)
+          (format "~n")))
 
-(thread-wait (watch-directories paths displayln displayln method))
+  (with-handlers ([exn:break? (λ (e) (printf "~nStopping...~n"))])
+    (thread-wait (watch paths displayln displayln method))
+    (displayln "All watchers are done.")))

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define scribblings '(("scribblings/file-watchers.scrbl" ())))
 (define pkg-desc "Recursive file system watching threads")
-(define version "0.1")
+(define version "0.2")
 (define pkg-authors '(Sage Gerard))
 (define raco-commands
   '(("file-watchers" (submod file-watchers/cli main) "Monitor files using file-watchers" #f)))

--- a/info.rkt
+++ b/info.rkt
@@ -8,4 +8,4 @@
 (define version "0.1")
 (define pkg-authors '(Sage Gerard))
 (define raco-commands
-  '(("file-watchers" file-watchers/cli "Monitor files using file-watchers" #f)))
+  '(("file-watchers" (submod file-watchers/cli main) "Monitor files using file-watchers" #f)))

--- a/intensive-watch.rkt
+++ b/intensive-watch.rkt
@@ -5,7 +5,7 @@
 
 (provide
   (contract-out
-    [intensive-watch  (->* () (directory-exists?) thread?)]))
+    [intensive-watch  (->* () (path-on-disk?) thread?)]))
 
 ;; ------------------------------------------------------------------ 
 ;; Implementation

--- a/main.rkt
+++ b/main.rkt
@@ -20,7 +20,12 @@
                               (-> list? any)
                               (-> list? any)
                               (-> path? thread?))
-                             thread?)]))
+                             thread?)]
+    [watch (->* () ((listof path-on-disk?)
+                    (-> list? any)
+                    (-> list? any)
+                    (-> path? thread?))
+                    thread?)]))
 
 ;; ------------------------------------------------------------------ 
 ;; Implementation
@@ -42,15 +47,22 @@
       (if apathetic apathetic-watch intensive-watch)
       robust-watch))
 
-(define (watch-directories
-          [directories (list (current-directory))]
+(define (watch
+          [paths (list (current-directory))]
           [on-activity displayln]
           [on-status displayln]
           [thread-maker (suggest-approach #:apathetic #f)])
-  (define watchers (map thread-maker directories))
+  (define watchers (map thread-maker paths))
   (thread (lambda () (let loop ()
     (define activity (async-channel-try-get (file-activity-channel)))
     (define status (async-channel-try-get (file-watcher-status-channel)))
     (when status (on-status status))
     (when activity (on-activity activity))
     (when (ormap thread-running? watchers) (loop))))))
+
+(define (watch-directories
+          [paths (list (current-directory))]
+          [on-activity displayln]
+          [on-status displayln]
+          [thread-maker (suggest-approach #:apathetic #f)])
+  (watch paths on-activity on-status thread-maker))

--- a/main.rkt
+++ b/main.rkt
@@ -9,6 +9,7 @@
   file-watcher-status-channel
   file-watcher-channel-try-get
   file-watcher-channel-get
+  path-on-disk?
   (all-from-out "./robust-watch.rkt")
   (all-from-out "./intensive-watch.rkt")
   (all-from-out "./apathetic-watch.rkt")

--- a/scribblings/file-watchers.scrbl
+++ b/scribblings/file-watchers.scrbl
@@ -104,27 +104,27 @@ Waits for and returns the next available message from @racket[file-watcher-statu
 @section{Detecting changes without concern for root cause}
 
 @defproc[#:kind "file-watcher"
-(apathetic-watch [path directory-exists?])
+(apathetic-watch [path path-on-disk?])
                  thread?]{
 
-An @italic{apathetic} thread recursively scans the given
-directory and waits for the first to trigger a
-@racket[filesystem-change-evt].}
+An @italic{apathetic} thread watches the file, directory, or link at the
+given path. It will signal any activity that triggers a @racket[filesystem-change-evt].
+The thread will terminate when no file, directory, or link exists at the given @racket[path].
 
-An apathetic thread reports a @racket[(list 'apathetic 'watching path)] status on
-@racket[file-watcher-status-channel] each time it starts waiting for a change.
-There are no other status messages and the thread will terminate
-when it can no longer access the directory located at the given @racket[path].
+If @racket[path] is a directory, @racket[apathetic-watch] will monitor all files recursively,
+but all changes within the directory are reported as changes to @racket[path].
 
-@racket[file-activity-channel] will only report
-@racket[(list 'apathetic 'change path)] when any change
-is detected.
+An apathetic watch:
+
+@itemlist[
+@item{...reports only @racket[(list 'apathetic 'watching path)] on @racket[file-watcher-status-channel] each time it starts waiting for a change.}
+@item{...reports only @racket[(list 'apathetic 'change path)] on @racket[file-activity-channel] when any change is detected.}]
 
 The below example starts an apathetic watch thread,
 waits for the thread to report that it is watching
 @racket["dir"], then deletes @racket["dir"].
-The apathetic watcher thread will report that the change occurred
-on @racket[file-activity-channel] before terminating,
+The apathetic watcher thread will report that
+the change occurred on @racket[file-activity-channel] before terminating,
 since @racket["dir"] was the root path for the
 watching thread.
 
@@ -137,8 +137,7 @@ watching thread.
 
 (thread-wait apathetic-watcher)
 (displayln (thread-dead? apathetic-watcher))
-]
-
+]}
 
 @section{Poll-based file monitoring}
 

--- a/scribblings/file-watchers.scrbl
+++ b/scribblings/file-watchers.scrbl
@@ -142,15 +142,14 @@ watching thread.
 @section{Poll-based file monitoring}
 
 @defproc[#:kind "file-watcher"
-(robust-watch [path directory-exists?])
+(robust-watch [path path-on-disk?])
               thread?]{
 
 A @racket[robust] watch operates on a polling mechanism that compares
-recursive listings of the given directory @racket[path] to report changes.
-This approach is cross-platform, but cannot detect any activity between
-filesystem polls.
+recursive listings of the @racket[path] to report changes. This approach
+is cross-platform, but cannot detect any activity between filesystem polls.
 
-Furthermore, @racket[robust-watch] only detects changes in file permissions and access time.
+Furthermore, @racket[robust-watch] will only compare file permissions and access times, not contents.
 
 @racket[robust-watch] only reports @racket['add], @racket['change], and @racket['remove]
 events on @racket[file-activity-channel]. It does not report status information

--- a/scribblings/file-watchers.scrbl
+++ b/scribblings/file-watchers.scrbl
@@ -17,10 +17,10 @@ For command-line use, use the @racket[file-watchers] raco command.
   $ raco file-watchers -h # For help
   $ raco file-watchers dir # Watch given directory
 
-  # Watch directories with a given method (methods documented below).
-  $ raco file-watchers -m apathetic dir
-  $ raco file-watchers -m robust dir
-  $ raco file-watchers -m intensive dir
+  # Watch files and directories with a given method (methods documented below).
+  $ raco file-watchers -m apathetic dir fileA fileB
+  $ raco file-watchers -m robust dir fileA fileB
+  $ raco file-watchers -m intensive dir fileA fileB
 }|
 
 For programmatic use, you can apply @racket[watch] to a list of targets.

--- a/scribblings/file-watchers.scrbl
+++ b/scribblings/file-watchers.scrbl
@@ -60,7 +60,7 @@ or a procedure that returns a thread created using one of those procedures.}
 Like @racket[watch], except the contract is restricted to directories.
 
 @bold{DEPRECATED:} Kept for backwards compatibility. This procedure will be removed
-on or after January 1, 2020.
+on or after January 1, 2020.}
 
 @defproc[(suggest-approach [#:apathetic apathetic boolean?])
          procedure?]{
@@ -71,6 +71,10 @@ If @racket[apathetic] is true, @racket[apathetic-watch] will be returned instead
 
 If file change events are not supported on the operating system or if file-level monitoring is unavailable,
 then @racket[robust-watch] is returned.}
+
+@defproc[(path-on-disk? [path path?]) boolean?]{
+Returns @racket[#t] if the @racket[path] is an existing file or directory on disk.
+}
 
 @section{Synchronization}
 

--- a/scribblings/file-watchers.scrbl
+++ b/scribblings/file-watchers.scrbl
@@ -59,8 +59,11 @@ or a procedure that returns a thread created using one of those procedures.}
   thread?]{
 Like @racket[watch], except the contract is restricted to directories.
 
-@bold{DEPRECATED:} Kept for backwards compatibility. This procedure will be removed
-on or after January 1, 2020.}
+
+@deprecated[#:what "procedure" @racket[watch]]{
+@racket[watch-directories] will be removed after January 1, 2020.}
+
+}
 
 @defproc[(suggest-approach [#:apathetic apathetic boolean?])
          procedure?]{


### PR DESCRIPTION
PR for version `0.2`.

* All file monitoring approaches can now target individual files as well as directories. 
* Expose `path-on-disk?` predicate as part of public API. It is equivalent to `(or (file-exists? _) (directory-exists? _))`.
* Upgrade CLI to provide cleaner feedback on ^C and watcher termination.
* Place CLI in `submod main` to avoid CI/CD pipeline counting it as a failing test
* Add `watch` as new API for simplified use. `watch-directories` marked as deprecated in docs. It will be removed on or after Jan 1st 2020.