### PR TITLE
Support batching messages in robust-watch

### DIFF
--- a/robust-watch.rkt
+++ b/robust-watch.rkt
@@ -11,7 +11,7 @@
 (provide
  (contract-out
   [robust-poll-milliseconds (parameter/c exact-positive-integer?)]
-  [robust-watch  (->* () (path-on-disk?) thread?)]))
+  [robust-watch  (->* () (path-on-disk? #:batch? boolean?) thread?)]))
 
 
 ;; ------------------------------------------------------------------

--- a/robust-watch.rkt
+++ b/robust-watch.rkt
@@ -3,21 +3,24 @@
 ;; This module provides a cross-platform, polling based file watch.
 
 (require
-  racket/contract)
+ racket/contract
+ racket/list
+ racket/set
+ )
 
 (provide
-  (contract-out
-    [robust-poll-milliseconds (parameter/c exact-positive-integer?)]
-    [robust-watch  (->* () (path-on-disk?) thread?)]))
+ (contract-out
+  [robust-poll-milliseconds (parameter/c exact-positive-integer?)]
+  [robust-watch  (->* () (path-on-disk?) thread?)]))
 
 
-;; ------------------------------------------------------------------ 
+;; ------------------------------------------------------------------
 ;; Implementation
 
 (require
-  racket/hash
-  "./filesystem.rkt"
-  "./threads.rkt")
+ racket/hash
+ "./filesystem.rkt"
+ "./threads.rkt")
 
 (define-values (report-activity report-status) (report-iface 'robust))
 
@@ -25,27 +28,27 @@
 
 (define (get-file-attributes path)
   (with-handlers ([exn:fail? (λ _ #f)])
-                 (cons (file-or-directory-modify-seconds path)
-                       (file-or-directory-permissions path 'bits))))
+    (cons (file-or-directory-modify-seconds path)
+          (file-or-directory-permissions path 'bits))))
 
 (define (get-listing-numbers listing)
   (foldl
-    (lambda (p res)
-      (define attrs (get-file-attributes p))
-      (append res (list
-                    (if (not attrs)
-                        -1
-                        (+ (car attrs) (cdr attrs))))))
-    '()
-    listing))
+   (lambda (p res)
+     (define attrs (get-file-attributes p))
+     (append res (list
+                  (if (not attrs)
+                      -1
+                      (+ (car attrs) (cdr attrs))))))
+   '()
+   listing))
 
 (define (get-robust-state path)
-    (define listing (if (file-exists? path)
-                        (list path)
-                        (recursive-file-list path)))
-    (make-immutable-hash (map cons
-                              listing
-                              (get-listing-numbers listing))))
+  (define listing (if (file-exists? path)
+                      (list path)
+                      (recursive-file-list path)))
+  (make-immutable-hash (map cons
+                            listing
+                            (get-listing-numbers listing))))
 
 (define (mark-changes prev next)
   (hash-union prev next
@@ -54,43 +57,61 @@
 
 (define (mark-status prev next)
   (make-immutable-hash
-    (map
-      (lambda (pair)
-        (if (symbol? (cdr pair))
+   (map
+    (lambda (pair)
+      (if (symbol? (cdr pair))
           pair
           (cons (car pair)
                 (if (path-on-disk? (car pair)) 'add 'remove))))
-      (hash->list (mark-changes prev next)))))
+    (hash->list (mark-changes prev next)))))
 
-(define (robust-watch [path (current-directory)])
+(define (robust-watch [path (current-directory)] #:batch? [batch? #f])
   (define complete (path->complete-path (simplify-path path #t)))
   (thread (lambda ()
-    (define initial (get-robust-state complete))
-    (let loop ([state initial])
-      (sync/enable-break (alarm-evt (+ (current-inexact-milliseconds)
-                                       (robust-poll-milliseconds))))
-      (if (path-on-disk? complete)
-        (let ([next (get-robust-state complete)])
-          (hash-for-each
-            (mark-status state next)
-            (lambda (affected op)
-              (unless (equal? op 'same)
-                (report-activity op affected))))
-          (loop next))
-        (report-activity 'remove complete))))))
+            (define initial (get-robust-state complete))
+            (let loop ([state initial])
+              (cond [(path-on-disk? complete)
+                     (let* ([next (get-robust-state complete)]
+                            [status-marked-hash (mark-status state next)]
+                            )
+                       (cond [(equal? #f batch?) ; no need to pull in racket/bool for one test
+                              ; we should NOT batch notifications
+                              (hash-for-each
+                               status-marked-hash
+                               (lambda (affected op)
+                                 (unless (equal? op 'same)
+                                   (report-activity op affected))))
+                              ]
+                             [else ; we SHOULD batch notifications
+
+                              (let* ([report (filter-not (lambda (arg) (equal? 'same (cdr arg)))
+                                                         (hash->list status-marked-hash))])
+                                (when (not (null? report))
+                                  (define messages
+                                    (for/list ([item report])
+                                      ;item looks like, e.g.:   (cons <path:/foo/bar> 'add)
+                                      (list 'robust (cdr item) (car item))))
+                                  (report-change-literal messages)))
+                              ]
+                             )
+                       (sync/enable-break (alarm-evt (+ (current-inexact-milliseconds)
+                                                        (robust-poll-milliseconds))))
+                       (loop next))]
+                    [else
+                     (report-activity 'remove complete)])))))
 
 
 (module+ test
   (require
-    rackunit
-    racket/async-channel
-    racket/file
-    (submod "./filesystem.rkt" test-lib)
-    (submod "./threads.rkt" test-lib))
+   rackunit
+   racket/async-channel
+   racket/file
+   (submod "./filesystem.rkt" test-lib)
+   (submod "./threads.rkt" test-lib))
 
   (define (allow-poll) (sleep (/ (robust-poll-milliseconds) 1000)))
   (test-case
-    "Robust watch over directory"
+      "Robust watch over directory, unbatched"
     (parameterize ([current-directory (create-temp-directory)]
                    [robust-poll-milliseconds 50]
                    [file-activity-channel (make-async-channel)])
@@ -107,9 +128,9 @@
 
       ; TODO: Paratition these messages into "may appear" and "must appear"
       (define expected-messages
-        `((robust change ,(build-path (current-directory) "c")) ; must
-          (robust remove ,(build-path (current-directory) "b")) ; may
-          (robust remove ,(build-path (current-directory)))))   ; must
+        `((robust change ,(build-path (current-directory) "c"))   ; must
+          (robust remove ,(build-path (current-directory) "b"))   ; may
+          (robust remove ,(build-path (current-directory)))))     ; must
 
       (let loop ()
         (define msg (file-watcher-channel-try-get))
@@ -117,8 +138,45 @@
           (check-true (and (member msg expected-messages) #t))
           (loop)))))
 
+
   (test-case
-    "Robust watch over file"
+      "Robust watch over directory, batched"
+    (parameterize ([current-directory (create-temp-directory)]
+                   [robust-poll-milliseconds 50]
+                   [file-activity-channel (make-async-channel)])
+      (define dir2  (create-temp-directory))
+      (parameterize ([current-directory dir2])
+        (make-directory* (build-path "foo" "bar" "baz"))
+        (current-directory (build-path "foo" "bar" "baz"))
+        (create-file "a.txt")
+        )
+
+      (define th (robust-watch #:batch? #t))
+
+      (allow-poll)
+
+      (rename-file-or-directory (build-path dir2 "foo")
+                                (build-path (current-directory) "foo"))
+      (delete-directory/files dir2)
+
+      (allow-poll)
+      (allow-poll)
+
+      (define messages (file-watcher-channel-try-get))
+
+      (allow-poll)
+
+      (define dir (current-directory))
+      (check-equal? (sort messages path<? #:key last)
+                    `((robust add ,(build-path dir "foo"))
+                      (robust add ,(build-path dir "foo/bar"))
+                      (robust add ,(build-path dir "foo/bar/baz"))
+                      (robust add ,(build-path dir "foo/bar/baz/a.txt"))))
+      (delete-directory/files (current-directory))
+      (thread-wait th)))
+
+  (test-case
+      "Robust watch over file"
     (parameterize ([current-directory (create-temp-directory)]
                    [robust-poll-milliseconds 50]
                    [file-activity-channel (make-async-channel)])
@@ -130,5 +188,5 @@
       (thread-wait th)
       (delete-directory/files (current-directory))
       (check-equal?
-        (sync (file-activity-channel))
-        `(robust remove ,(build-path (current-directory) "a"))))))
+       (sync (file-activity-channel))
+       `(robust remove ,(build-path (current-directory) "a"))))))

--- a/threads.rkt
+++ b/threads.rkt
@@ -1,22 +1,23 @@
 #lang racket/base
 
 (require
-  racket/contract)
+ racket/contract)
 
 (provide
-  report-iface
-  (contract-out
-    [file-watcher-channel-try-get (-> (or/c boolean? list?))]
-    [file-watcher-channel-get (-> list?)]
-    [file-watcher-status-channel (parameter/c async-channel?)]
-    [file-activity-channel (parameter/c async-channel?)]))
+ report-iface
+ report-change-literal
+ (contract-out
+  [file-watcher-channel-try-get (-> (or/c boolean? list?))]
+  [file-watcher-channel-get (-> list?)]
+  [file-watcher-status-channel (parameter/c async-channel?)]
+  [file-activity-channel (parameter/c async-channel?)]))
 
 
-;; ------------------------------------------------------------------ 
+;; ------------------------------------------------------------------
 ;; Implementation
 
 (require
-  racket/async-channel)
+ racket/async-channel)
 
 (define file-activity-channel (make-parameter (make-async-channel)))
 (define file-watcher-status-channel (make-parameter (make-async-channel)))
@@ -35,6 +36,9 @@
 (define (report-change . rest)
   (async-channel-put (file-activity-channel) rest))
 
+(define (report-change-literal arg)
+  (async-channel-put (file-activity-channel) arg))
+
 (define (report-status . rest)
   (async-channel-put (file-watcher-status-channel) rest))
 
@@ -48,25 +52,25 @@
 
 (module+ test-lib
   (provide
-    (contract-out
-      [set-alarm       (->* () (positive-integer?) evt?)]
-      [expect-status   (-> list? any)]
-      [expect-activity (-> list? any)]
-      [expect-silence  (-> any)]))
+   (contract-out
+    [set-alarm       (->* () (positive-integer?) evt?)]
+    [expect-status   (-> list? any)]
+    [expect-activity (-> list? any)]
+    [expect-silence  (-> any)]))
 
   (require
-    rackunit
-    racket/math
-    racket/format)
+   rackunit
+   racket/math
+   racket/format)
 
   (define (set-alarm [ms 100])
     (alarm-evt (+ (current-inexact-milliseconds) ms)))
 
   (define (expect-message channel message)
     (check-equal?
-      (sync channel (set-alarm))
-      message
-      (~a "Waiting for" message)))
+     (sync channel (set-alarm))
+     message
+     (~a "Waiting for" message)))
 
   (define (expect-activity message)
     (expect-message (file-activity-channel) message))


### PR DESCRIPTION
First, the sleep in robust-watch gets moved to the bottom of the loop so that initial setup is faster.

More importantly, robust-watch gains a new optional argument:  #:batch? boolean?

The default is #f, meaning reporting behavior will be unchanged from before this PR.

If set to #t, all activity messages for that loop will be sent via a single async-channel-put instead of a -put for each message.  e.g., instead of reporting four separate changes, it will report this:

'(
(robust add <path:/foo/bar>)
(robust add <path:/foo/bar/baz.txt>)
(robust change <path:/foo/jaz.txt>)
(robust removed <path:/foo/quux.txt>)
)