### PR TITLE
Add high-level delay argument

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -19,15 +19,17 @@
                              ((listof directory-exists?)
                               (-> list? any)
                               (-> list? any)
-                              (-> path? thread?))
+                              (-> path? thread?)
+                              #:delay positive?)
                              thread?)]
     [watch (->* () ((listof path-on-disk?)
                     (-> list? any)
                     (-> list? any)
-                    (-> path? thread?))
+                    (-> path? thread?)
+                    #:delay positive?)
                     thread?)]))
 
-;; ------------------------------------------------------------------ 
+;; ------------------------------------------------------------------
 ;; Implementation
 
 (require
@@ -51,18 +53,22 @@
           [paths (list (current-directory))]
           [on-activity displayln]
           [on-status displayln]
-          [thread-maker (suggest-approach #:apathetic #f)])
+          [thread-maker (suggest-approach #:apathetic #f)]
+          #:delay [delay-seconds 1])
   (define watchers (map thread-maker paths))
   (thread (lambda () (let loop ()
     (define activity (async-channel-try-get (file-activity-channel)))
     (define status (async-channel-try-get (file-watcher-status-channel)))
     (when status (on-status status))
     (when activity (on-activity activity))
-    (when (ormap thread-running? watchers) (loop))))))
+    (when (ormap thread-running? watchers)
+      (sleep delay-seconds)
+      (loop))))))
 
 (define (watch-directories
           [paths (list (current-directory))]
           [on-activity displayln]
           [on-status displayln]
-          [thread-maker (suggest-approach #:apathetic #f)])
-  (watch paths on-activity on-status thread-maker))
+          [thread-maker (suggest-approach #:apathetic #f)]
+          #:delay [delay-seconds 1])
+  (watch paths on-activity on-status thread-maker #:delay delay-seconds))

--- a/scribblings/file-watchers.scrbl
+++ b/scribblings/file-watchers.scrbl
@@ -38,14 +38,16 @@ will appear via @racket[displayln].
   [paths (listof path-on-disk?) (list (current-directory))]
   [on-activity (-> list? any) displayln]
   [on-status (-> list? any) displayln]
-  [thread-maker (-> path? thread?) (suggest-approach #:apathetic #f)])
+  [thread-maker (-> path? thread?) (suggest-approach #:apathetic #f)]
+  [#:delay delay-time positive? 1])
   thread?]{
 Returns a thread that watches all given paths representing files or directories
 on disk. For each path, @racket[thread-maker] is invoked to create a subordinate
 thread to monitor that path.
 
 The thread returned from @racket[watch] will wait for all subordinate threads
-to terminate before it itself terminates. Breaking is enabled.
+to terminate before it itself terminates. Breaking is enabled, and the watch
+will yield time to other threads every @racket[delay-time] seconds.
 
 @racket[thread-maker] should either be one of @racket[apathetic-watch], @racket[intensive-watch], or @racket[robust-watch],
 or a procedure that returns a thread created using one of those procedures.}
@@ -55,14 +57,13 @@ or a procedure that returns a thread created using one of those procedures.}
   [directories (listof directory-exists?) (list (current-directory))]
   [on-activity (-> list? any) displayln]
   [on-status (-> list? any) displayln]
-  [thread-maker (-> path? thread?) (suggest-approach #:apathetic #f)])
-  thread?]{
+  [thread-maker (-> path? thread?) (suggest-approach #:apathetic #f)]
+  [#:delay delay-time positive? 1])
+thread?]{
 Like @racket[watch], except the contract is restricted to directories.
-
 
 @deprecated[#:what "procedure" @racket[watch]]{
 @racket[watch-directories] will be removed after January 1, 2020.}
-
 }
 
 @defproc[(suggest-approach [#:apathetic apathetic boolean?])


### PR DESCRIPTION
Re: #10

The loop in `watch` doesn't yield enough time to other threads. To alleviate high CPU usage, I added a configurable `sleep`. The default of one second is a big decision, hence the PR for users.